### PR TITLE
Switches justified text to left-aligned text.

### DIFF
--- a/profiles/smash/themes/custom/smash2013/css/navigation.css
+++ b/profiles/smash/themes/custom/smash2013/css/navigation.css
@@ -79,7 +79,7 @@ li a.active {
 #navigation ul.menu {
   margin: 0;
   padding: 0;
-  text-align: justify;
+  text-align: left;
 }
 /* line 68, ../sass/navigation.scss */
 #navigation ul.links li, #navigation ul.links .item-list,
@@ -211,7 +211,7 @@ li a.active {
   padding: 0.625em 0.25em;
   color: white;
   text-decoration: none;
-  text-align: justify;
+  text-align: left;
   background-color: #282828;
 }
 /* line 198, ../sass/navigation.scss */
@@ -225,7 +225,7 @@ li a.active {
 /* line 206, ../sass/navigation.scss */
 .block-menu-block .menu li.nolink {
   background-color: #282828;
-  text-align: justify;
+  text-align: left;
   text-transform: uppercase;
   color: #3ec1c7;
   font-weight: bold;
@@ -247,7 +247,7 @@ li a.active {
   padding: 0.625em 6px;
   background-color: #282828;
   margin: 0;
-  text-align: justify;
+  text-align: left;
   min-height: 22px;
   font-size: 1em;
   text-transform: uppercase;
@@ -427,7 +427,7 @@ li a.active {
     float: none;
     display: block;
     margin: 0;
-    text-align: justify;
+    text-align: left;
   }
   /* line 418, ../sass/navigation.scss */
   .block-menu-block .menu li > .menu-wrapper .menu li.nolink {

--- a/profiles/smash/themes/custom/smash2013/css/normalize.css
+++ b/profiles/smash/themes/custom/smash2013/css/normalize.css
@@ -696,7 +696,7 @@ table {
  */
 /* line 671, ../sass/normalize.scss */
 th {
-  text-align: justify;
+  text-align: left;
   /* LTR */
   padding: 0;
   border-bottom: none;

--- a/profiles/smash/themes/custom/smash2013/css/pages.css
+++ b/profiles/smash/themes/custom/smash2013/css/pages.css
@@ -32,7 +32,7 @@
 body {
   margin: 0;
   padding: 0;
-  text-align: justify;
+  text-align: left;
   background-color: #282828;
   background: url(../images/2013webgradient.png) fixed repeat-x bottom center, url(../images/2013webbg.png) repeat top center, #282828;
   background-size: 1px 1300px, 100px 113px;

--- a/profiles/smash/themes/custom/smash2013/sass/navigation.scss
+++ b/profiles/smash/themes/custom/smash2013/sass/navigation.scss
@@ -63,7 +63,7 @@ li a.active {
   ul.menu {
     margin: 0;
     padding: 0;
-    text-align: justify;
+    text-align: left;
 
     li, .item-list {
       list-style-type: none;
@@ -192,7 +192,7 @@ li a.active {
         padding: 0.625em 0.25em;
         color: white;
         text-decoration: none;
-        text-align: justify;
+        text-align: left;
         background-color: $color-menu-hov;
         
         &:hover, &:focus, &:active {
@@ -205,7 +205,7 @@ li a.active {
       
       &.nolink {
         background-color: $color-menu-hov;
-        text-align: justify;
+        text-align: left;
         @include menu-heading-style;
         min-height: 22px;
       }
@@ -224,7 +224,7 @@ li a.active {
     padding: 0.625em 6px;
     background-color: $color-menu-hov;
     margin: 0;
-    text-align: justify;
+    text-align: left;
     min-height: 22px;
     
     font-size: 1em;    
@@ -413,7 +413,7 @@ li a.active {
               float: none;
               display: block;
               margin: 0;
-              text-align: justify;
+              text-align: left;
               
               &.nolink {
                 margin-top: 0.5em;

--- a/profiles/smash/themes/custom/smash2013/sass/normalize.scss
+++ b/profiles/smash/themes/custom/smash2013/sass/normalize.scss
@@ -669,7 +669,7 @@ table {
  */
 
 th {
-  text-align: justify; /* LTR */
+  text-align: left; /* LTR */
   padding: 0;
   border-bottom: none;
 }

--- a/profiles/smash/themes/custom/smash2013/sass/pages.scss
+++ b/profiles/smash/themes/custom/smash2013/sass/pages.scss
@@ -17,7 +17,7 @@
 body {
   margin: 0;
   padding: 0;
-  text-align: justify;
+  text-align: left;
   background-color: $color-menu-hov;
   background: 
 	url(../images/2013webgradient.png) fixed repeat-x bottom center, 


### PR DESCRIPTION
It's really easy for justified text to look start looking horrible:

![Menu and CTA](https://f.cloud.github.com/assets/133028/505846/c4814bac-bd39-11e2-8e70-cfea0d86cf22.png)

(Particularly, the navigation item text, the CTA header, and the rivers of text in the body copy.)

This change switches `text-align: justify;` to `text-align: left;` in a bunch of places.
